### PR TITLE
fix: robustness fixes for the public Gemini Developer API path

### DIFF
--- a/agents/best_image_selector.py
+++ b/agents/best_image_selector.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field
 from tenacity import retry, stop_after_attempt
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.output_parsers import PydanticOutputParser
+from utils.robust_json_parser import TrailingCommaTolerantPydanticOutputParser as PydanticOutputParser
 from langchain.chat_models import init_chat_model
 from utils.image import image_path_to_b64
 

--- a/agents/camera_image_generator.py
+++ b/agents/camera_image_generator.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 from tenacity import retry, stop_after_attempt
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.output_parsers import PydanticOutputParser
+from utils.robust_json_parser import TrailingCommaTolerantPydanticOutputParser as PydanticOutputParser
 from scenedetect import open_video, SceneManager, split_video_ffmpeg
 from scenedetect.detectors import ContentDetector
 

--- a/agents/character_extractor.py
+++ b/agents/character_extractor.py
@@ -1,6 +1,7 @@
 import logging
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import PydanticOutputParser
+from utils.robust_json_parser import TrailingCommaTolerantPydanticOutputParser as PydanticOutputParser
 from langchain.chat_models.base import BaseChatModel
 from langchain.chat_models import init_chat_model
 from pydantic import BaseModel, Field

--- a/agents/character_portraits_generator.py
+++ b/agents/character_portraits_generator.py
@@ -43,7 +43,7 @@ class CharacterPortraitsGenerator:
         character: CharacterInScene,
         style: str,
     ) -> ImageOutput:
-        features = "(static) " + character.static_features + "; (dynamic) " + character.dynamic_features
+        features = "(static) " + (character.static_features or "") + "; (dynamic) " + (character.dynamic_features or "")
         prompt = prompt_template_front.format(
             identifier=character.identifier_in_scene,
             features=features,

--- a/agents/event_extractor.py
+++ b/agents/event_extractor.py
@@ -4,6 +4,7 @@ import asyncio
 from typing import List
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.output_parsers import PydanticOutputParser
+from utils.robust_json_parser import TrailingCommaTolerantPydanticOutputParser as PydanticOutputParser
 from langchain.chat_models import init_chat_model
 from pydantic import BaseModel, Field
 from tenacity import retry, stop_after_attempt

--- a/agents/reference_image_selector.py
+++ b/agents/reference_image_selector.py
@@ -4,6 +4,7 @@ from tenacity import retry, stop_after_attempt
 from pydantic import BaseModel, Field
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.output_parsers import PydanticOutputParser
+from utils.robust_json_parser import TrailingCommaTolerantPydanticOutputParser as PydanticOutputParser
 from langchain.chat_models import init_chat_model
 from utils.image import image_path_to_b64
 

--- a/agents/scene_extractor.py
+++ b/agents/scene_extractor.py
@@ -5,6 +5,7 @@ from langchain.chat_models import init_chat_model
 from pydantic import BaseModel, Field
 from typing import List, Optional, Literal, Tuple, Dict
 from langchain_core.output_parsers import PydanticOutputParser
+from utils.robust_json_parser import TrailingCommaTolerantPydanticOutputParser as PydanticOutputParser
 from tenacity import retry, stop_after_attempt
 import logging
 

--- a/agents/screenwriter.py
+++ b/agents/screenwriter.py
@@ -2,6 +2,7 @@ import logging
 from typing import List, Optional
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import PydanticOutputParser
+from utils.robust_json_parser import TrailingCommaTolerantPydanticOutputParser as PydanticOutputParser
 from langchain.chat_models import init_chat_model
 from pydantic import BaseModel, Field
 from tenacity import retry, stop_after_attempt, wait_exponential

--- a/agents/script_enhancer.py
+++ b/agents/script_enhancer.py
@@ -1,6 +1,7 @@
 import logging
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import PydanticOutputParser
+from utils.robust_json_parser import TrailingCommaTolerantPydanticOutputParser as PydanticOutputParser
 from langchain.chat_models import init_chat_model
 from pydantic import BaseModel, Field
 from tenacity import retry, stop_after_attempt

--- a/agents/script_planner.py
+++ b/agents/script_planner.py
@@ -1,6 +1,7 @@
 import logging
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import PydanticOutputParser
+from utils.robust_json_parser import TrailingCommaTolerantPydanticOutputParser as PydanticOutputParser
 from langchain.chat_models import init_chat_model
 from pydantic import BaseModel, Field
 from typing import List, Optional, Literal

--- a/interfaces/character.py
+++ b/interfaces/character.py
@@ -24,7 +24,8 @@ class CharacterInScene(BaseModel):
             "Bob the Builder is a middle-aged man with a sturdy build.",
         ]
     )
-    dynamic_features: str = Field(
+    dynamic_features: Optional[str] = Field(
+        default=None,
         description="The dynamic features of the character in this specific scene, such as clothing and accessories that may change from scene to scene. If not mentioned, this field can be left empty. If the character is not visible, this field should be None.",
         examples=[
             "Wearing a red scarf and a black leather jacket",

--- a/pipelines/idea2video_pipeline.py
+++ b/pipelines/idea2video_pipeline.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import logging
 from agents import Screenwriter, CharacterExtractor, CharacterPortraitsGenerator
 from pipelines.script2video_pipeline import Script2VideoPipeline
@@ -96,6 +97,11 @@ class Idea2VideoPipeline:
             self.generate_portraits_for_single_character(character, style)
             for character in characters
             if character.identifier_in_scene not in character_portraits_registry
+            # Characters never shown on screen (e.g. a voice or chat-only
+            # character) have no physical description, so asking the image
+            # model for front/side/back portraits of them is nonsensical and
+            # fails repeatedly (finish_reason=IMAGE_OTHER, empty candidates).
+            and character.is_visible
         ]
         if tasks:
             for future in asyncio.as_completed(tasks):
@@ -171,15 +177,28 @@ class Idea2VideoPipeline:
         if os.path.exists(side_portrait_path):
             pass
         else:
-            side_portrait_output = await self.character_portraits_generator.generate_side_portrait(character, front_portrait_path)
-            side_portrait_output.save(side_portrait_path)
+            try:
+                side_portrait_output = await self.character_portraits_generator.generate_side_portrait(character, front_portrait_path)
+                side_portrait_output.save(side_portrait_path)
+            except Exception as e:
+                # gemini-2.5-flash-image intermittently (sometimes beyond
+                # the tenacity retry budget) fails this front->side
+                # re-angling edit with finish_reason=IMAGE_OTHER / empty
+                # content. Fall back to the front portrait rather than
+                # aborting the whole pipeline.
+                print(f"⚠️ Side portrait generation failed for {character.identifier_in_scene} after retries ({e}); reusing front portrait as fallback.")
+                shutil.copy(front_portrait_path, side_portrait_path)
 
         back_portrait_path = os.path.join(character_dir, "back.png")
         if os.path.exists(back_portrait_path):
             pass
         else:
-            back_portrait_output = await self.character_portraits_generator.generate_back_portrait(character, front_portrait_path)
-            back_portrait_output.save(back_portrait_path)
+            try:
+                back_portrait_output = await self.character_portraits_generator.generate_back_portrait(character, front_portrait_path)
+                back_portrait_output.save(back_portrait_path)
+            except Exception as e:
+                print(f"⚠️ Back portrait generation failed for {character.identifier_in_scene} after retries ({e}); reusing front portrait as fallback.")
+                shutil.copy(front_portrait_path, back_portrait_path)
 
         print(
             f"☑️ Completed character portrait generation for {character.identifier_in_scene}.")

--- a/tools/video_generator_veo_google_api.py
+++ b/tools/video_generator_veo_google_api.py
@@ -28,7 +28,7 @@ class VideoGeneratorVeoGoogleAPI:
         self.client = genai.Client(
             api_key=api_key,
         )
-    
+
     async def generate_single_video(
         self,
         prompt: str,
@@ -53,9 +53,19 @@ class VideoGeneratorVeoGoogleAPI:
             params["model"] = self.ff2v_model
             params["image"] = types.Image.from_file(location=reference_image_paths[0])
         elif len(reference_image_paths) == 2:
-            params["model"] = self.flf2v_model
+            # First+last-frame ("flf2v") interpolation returns 400
+            # INVALID_ARGUMENT ("Your use case is currently not supported")
+            # on the public Gemini Developer API (it appears to require
+            # Vertex AI / allowlisting). Fall back to first-frame-only so
+            # the shot still renders instead of failing the pipeline; the
+            # clip just is not pinned to the generated last frame.
+            logging.warning(
+                "Two reference images provided but first+last-frame video "
+                "generation is not available on this API key; falling back "
+                "to first-frame-only generation."
+            )
+            params["model"] = self.ff2v_model
             params["image"] = types.Image.from_file(location=reference_image_paths[0])
-            config_params["last_frame"] = types.Image.from_file(location=reference_image_paths[1])
         else:
             raise ValueError("The number of reference images must be no more than 2")
 
@@ -77,7 +87,10 @@ class VideoGeneratorVeoGoogleAPI:
                 )
                 break
             except ClientError as e:
-                if e.status_code == 429 and attempt < max_retries - 1:
+                # google.genai.errors.ClientError exposes the HTTP status
+                # as `.code`; `.status_code` does not exist, so this line
+                # raised AttributeError and masked every real ClientError.
+                if e.code == 429 and attempt < max_retries - 1:
                     wait_time = retry_delay * (2 ** attempt)
                     logging.warning(f"Rate limit hit (429), retrying in {wait_time}s... (attempt {attempt + 1}/{max_retries})")
                     await asyncio.sleep(wait_time)

--- a/utils/robust_json_parser.py
+++ b/utils/robust_json_parser.py
@@ -1,0 +1,36 @@
+# Some chat models (observed with gemini-flash-lite via the OpenAI-compatible
+# endpoint) frequently emit a trailing comma before a closing `}`/`]` in
+# structured JSON responses (e.g. `"variation_reason": "...",\n}`). That is
+# invalid JSON, so PydanticOutputParser raises OutputParserException even
+# though the payload is otherwise well-formed and semantically complete --
+# and resampling burns LLM calls while often failing the same way again.
+# Wrap PydanticOutputParser so a parse failure retries locally with trailing
+# commas stripped before giving up.
+import re
+from typing import List, Optional
+
+from langchain_core.exceptions import OutputParserException
+from langchain_core.output_parsers import PydanticOutputParser
+from langchain_core.outputs import Generation
+
+_TRAILING_COMMA_RE = re.compile(r",(\s*[}\]])")
+
+
+def strip_trailing_commas(text: str) -> str:
+    return _TRAILING_COMMA_RE.sub(r"\1", text)
+
+
+class TrailingCommaTolerantPydanticOutputParser(PydanticOutputParser):
+    """PydanticOutputParser that retries once with trailing commas stripped."""
+
+    def parse_result(self, result: List[Generation], *, partial: bool = False):
+        try:
+            return super().parse_result(result, partial=partial)
+        except OutputParserException:
+            if not result:
+                raise
+            cleaned_text = strip_trailing_commas(result[0].text)
+            if cleaned_text == result[0].text:
+                raise
+            cleaned_result = [Generation(text=cleaned_text)]
+            return super().parse_result(cleaned_result, partial=partial)


### PR DESCRIPTION
Four fixes found while running the idea2video pipeline end-to-end on a plain **Gemini Developer API key** (no Vertex AI). Happy to split into separate PRs if you prefer.

## 1. `ClientError.status_code` → `.code` (bug, always broken)
`tools/video_generator_veo_google_api.py`'s 429 retry handler reads `e.status_code`, which doesn't exist on `google.genai.errors.ClientError` (the HTTP status is `.code`). The resulting `AttributeError` masks every real `ClientError`, so rate-limit retries never actually ran.

## 2. flf2v → ff2v fallback on the public API
First+last-frame generation returns `400 INVALID_ARGUMENT — "Your use case is currently not supported"` via the Gemini Developer API (it appears to need Vertex AI / allowlisting). Instead of failing the shot, fall back to first-frame-only with a warning — the clip renders, it's just not pinned to the generated last frame.

## 3. Trailing-comma-tolerant JSON parsing
gemini-flash-lite-class models frequently emit a trailing comma before `}`/`]` in structured responses, which `PydanticOutputParser` rejects — and resampling often fails the same way again (we saw `storyboard_artist` exhaust its full retry budget twice in a row on this). New `utils/robust_json_parser.py` wraps the parser to retry locally with trailing commas stripped; agents use it via a drop-in aliased import.

## 4. Portrait-stage robustness
- Skip portrait generation for characters with `is_visible == False` (a chat-only/voice-only character has no physical description; asking for front/side/back portraits fails repeatedly with `finish_reason=IMAGE_OTHER`, empty candidates).
- `Character.dynamic_features` becomes `Optional` with None-safe formatting (the extractor legitimately returns nothing for such characters).
- When side/back re-angling of a valid front portrait fails persistently, reuse the front portrait instead of aborting the entire pipeline.

All observed and reproduced during a real end-to-end run (2-shot promo brief, veo-3.1 + gemini-flash-lite + nanobanana); no behavior changes for the Vertex path or default configs beyond the bug fix in (1).