### PR TITLE
fix(novel2movie): avoid ZeroDivisionError on empty novel text

### DIFF
--- a/pipelines/novel2movie_pipeline.py
+++ b/pipelines/novel2movie_pipeline.py
@@ -22,7 +22,7 @@ from interfaces import (
 )
 from tenacity import retry
 
-from utils.text import safe_path_component
+from utils.text import safe_path_component, compression_ratio_label
 
 
 
@@ -546,7 +546,7 @@ class Novel2MoviePipeline:
         print("📌 Summary:")
         print(f"📌 Before Compression: {len(novel_text)} characters")
         print(f"📌 After Compression: {len(compressed_novel)} characters")
-        print(f"📌 Compression Ratio: {len(compressed_novel) / len(novel_text):.2%}")
+        print(compression_ratio_label(novel_text, compressed_novel))
 
         print("📋 Step 1: Compress the novel text".center(80, "-"))
 

--- a/tests/test_novel2movie_empty_ratio.py
+++ b/tests/test_novel2movie_empty_ratio.py
@@ -1,0 +1,20 @@
+"""Empty novel_text must not ZeroDivisionError on compression summary."""
+
+from __future__ import annotations
+
+import pytest
+
+from utils.text import compression_ratio_label
+
+
+def test_empty_novel_ratio_is_na() -> None:
+    assert compression_ratio_label("", "") == "📌 Compression Ratio: n/a (empty novel text)"
+
+
+def test_nonempty_novel_ratio_formats() -> None:
+    assert compression_ratio_label("abcd", "ab") == "📌 Compression Ratio: 50.00%"
+
+
+def test_unfixed_formula_zerodivs_on_empty() -> None:
+    with pytest.raises(ZeroDivisionError):
+        _ = len("") / len("")

--- a/tests/test_novel2movie_empty_ratio.py
+++ b/tests/test_novel2movie_empty_ratio.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from utils.text import compression_ratio_label
 
 
@@ -15,6 +13,3 @@ def test_nonempty_novel_ratio_formats() -> None:
     assert compression_ratio_label("abcd", "ab") == "📌 Compression Ratio: 50.00%"
 
 
-def test_unfixed_formula_zerodivs_on_empty() -> None:
-    with pytest.raises(ZeroDivisionError):
-        _ = len("") / len("")

--- a/utils/text.py
+++ b/utils/text.py
@@ -12,3 +12,10 @@ def safe_path_component(name) -> str:
     cleaned = re.sub(r"[^\w\-. ]", "_", str(name))
     cleaned = cleaned.strip().lstrip(".")
     return cleaned or "unnamed"
+
+
+def compression_ratio_label(novel_text: str, compressed_novel: str) -> str:
+    """Format compression-ratio summary; empty novel is n/a, not ZeroDivision."""
+    if not novel_text:
+        return "📌 Compression Ratio: n/a (empty novel text)"
+    return f"📌 Compression Ratio: {len(compressed_novel) / len(novel_text):.2%}"


### PR DESCRIPTION
The novel2movie compression summary divided by `len(novel_text)` with no empty guard. An empty novel (or resume with an empty compressed artifact) raised `ZeroDivisionError` before later steps.

`compression_ratio_label` now prints `n/a` when the novel text is empty.

Repro: `compression_ratio_label("", "")` must not divide by zero; it returns the n/a label.