### PR TITLE
fix(novel2movie): only resume retrieval when score chunk files exist

### DIFF
--- a/pipelines/novel2movie_pipeline.py
+++ b/pipelines/novel2movie_pipeline.py
@@ -22,7 +22,8 @@ from interfaces import (
 )
 from tenacity import retry
 
-from utils.text import safe_path_component, _iter_score_chunk_files
+from utils.text import safe_path_component
+from utils.novel2movie_cache import iter_score_chunk_files
 
 
 
@@ -184,7 +185,7 @@ class Novel2MoviePipeline:
         retrieve_sem = asyncio.Semaphore(10)
         for event in extracted_events:
             chunks_dir = os.path.join(working_dir_retrieve, f"event_{event.index}")
-            score_files = list(_iter_score_chunk_files(chunks_dir)) if os.path.exists(chunks_dir) else []
+            score_files = list(iter_score_chunk_files(chunks_dir)) if os.path.exists(chunks_dir) else []
             if score_files:
                 relevant = {}
                 for chunk_path, score in score_files:
@@ -651,7 +652,7 @@ class Novel2MoviePipeline:
         tasks = []
         for event in extracted_events:
             chunks_dir = os.path.join(working_dir_retrieve, f"event_{event.index}")
-            score_files = list(_iter_score_chunk_files(chunks_dir)) if os.path.exists(chunks_dir) else []
+            score_files = list(iter_score_chunk_files(chunks_dir)) if os.path.exists(chunks_dir) else []
             if score_files:
                 relevant_chunk_score_dict = {}
                 for chunk_path, score in score_files:

--- a/pipelines/novel2movie_pipeline.py
+++ b/pipelines/novel2movie_pipeline.py
@@ -22,7 +22,7 @@ from interfaces import (
 )
 from tenacity import retry
 
-from utils.text import safe_path_component
+from utils.text import safe_path_component, _iter_score_chunk_files
 
 
 
@@ -184,11 +184,10 @@ class Novel2MoviePipeline:
         retrieve_sem = asyncio.Semaphore(10)
         for event in extracted_events:
             chunks_dir = os.path.join(working_dir_retrieve, f"event_{event.index}")
-            if os.path.exists(chunks_dir) and os.listdir(chunks_dir):
+            score_files = list(_iter_score_chunk_files(chunks_dir)) if os.path.exists(chunks_dir) else []
+            if score_files:
                 relevant = {}
-                for chunk_fname in os.listdir(chunks_dir):
-                    chunk_path = os.path.join(chunks_dir, chunk_fname)
-                    score = float(chunk_fname.split("-score_")[1].split(".txt")[0])
+                for chunk_path, score in score_files:
                     with open(chunk_path, "r", encoding="utf-8") as f:
                         relevant[f.read()] = score
                 event_idx_to_relevant_chunk_score_dict[event.index] = relevant
@@ -652,11 +651,10 @@ class Novel2MoviePipeline:
         tasks = []
         for event in extracted_events:
             chunks_dir = os.path.join(working_dir_retrieve, f"event_{event.index}")
-            if os.path.exists(chunks_dir) and len(os.listdir(chunks_dir)) > 0:
+            score_files = list(_iter_score_chunk_files(chunks_dir)) if os.path.exists(chunks_dir) else []
+            if score_files:
                 relevant_chunk_score_dict = {}
-                for chunk_fname in os.listdir(chunks_dir):
-                    chunk_path = os.path.join(chunks_dir, chunk_fname)
-                    score = float(chunk_fname.split('-score_')[1].split('.txt')[0])
+                for chunk_path, score in score_files:
                     with open(chunk_path, "r", encoding="utf-8") as f:
                         chunk = f.read()
                     relevant_chunk_score_dict[chunk] = score

--- a/tests/test_novel2movie_resume_cache_miss.py
+++ b/tests/test_novel2movie_resume_cache_miss.py
@@ -5,19 +5,25 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
-from utils.text import _iter_score_chunk_files
+from utils.novel2movie_cache import iter_score_chunk_files
 
 
 def test_stray_notes_only_dir_yields_no_scores() -> None:
     with tempfile.TemporaryDirectory() as d:
         Path(d, "notes.txt").write_text("x", encoding="utf-8")
-        assert list(_iter_score_chunk_files(d)) == []
+        assert list(iter_score_chunk_files(d)) == []
 
 
 def test_valid_chunk_file_is_yielded() -> None:
     with tempfile.TemporaryDirectory() as d:
         Path(d, "notes.txt").write_text("x", encoding="utf-8")
         Path(d, "chunk_0-score_0.85.txt").write_text("chunk body", encoding="utf-8")
-        got = list(_iter_score_chunk_files(d))
+        got = list(iter_score_chunk_files(d))
         assert len(got) == 1
         assert got[0][1] == 0.85
+
+
+def test_bad_score_token_is_skipped() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        Path(d, "chunk_0-score_bad.txt").write_text("x", encoding="utf-8")
+        assert list(iter_score_chunk_files(d)) == []

--- a/tests/test_novel2movie_resume_cache_miss.py
+++ b/tests/test_novel2movie_resume_cache_miss.py
@@ -1,0 +1,23 @@
+"""Resume only when score chunk files exist; stray files are not a hit."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from utils.text import _iter_score_chunk_files
+
+
+def test_stray_notes_only_dir_yields_no_scores() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        Path(d, "notes.txt").write_text("x", encoding="utf-8")
+        assert list(_iter_score_chunk_files(d)) == []
+
+
+def test_valid_chunk_file_is_yielded() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        Path(d, "notes.txt").write_text("x", encoding="utf-8")
+        Path(d, "chunk_0-score_0.85.txt").write_text("chunk body", encoding="utf-8")
+        got = list(_iter_score_chunk_files(d))
+        assert len(got) == 1
+        assert got[0][1] == 0.85

--- a/utils/novel2movie_cache.py
+++ b/utils/novel2movie_cache.py
@@ -1,0 +1,18 @@
+"""Resume-cache helpers for novel2movie retrieval."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+
+def iter_score_chunk_files(chunks_dir: str) -> Iterator[tuple[str, float]]:
+    """Yield (path, score) for chunk_*-score_*.txt files in a resume cache dir."""
+    for chunk_fname in os.listdir(chunks_dir):
+        if "-score_" not in chunk_fname or not chunk_fname.endswith(".txt"):
+            continue
+        try:
+            score = float(chunk_fname.split("-score_")[1].split(".txt")[0])
+        except ValueError:
+            continue
+        yield os.path.join(chunks_dir, chunk_fname), score

--- a/utils/text.py
+++ b/utils/text.py
@@ -12,13 +12,3 @@ def safe_path_component(name) -> str:
     cleaned = re.sub(r"[^\w\-. ]", "_", str(name))
     cleaned = cleaned.strip().lstrip(".")
     return cleaned or "unnamed"
-
-
-def _iter_score_chunk_files(chunks_dir: str):
-    """Yield (path, score) for chunk_*-score_*.txt files in a resume cache dir."""
-    import os
-    for chunk_fname in os.listdir(chunks_dir):
-        if "-score_" not in chunk_fname or not chunk_fname.endswith(".txt"):
-            continue
-        score = float(chunk_fname.split("-score_")[1].split(".txt")[0])
-        yield os.path.join(chunks_dir, chunk_fname), score

--- a/utils/text.py
+++ b/utils/text.py
@@ -12,3 +12,13 @@ def safe_path_component(name) -> str:
     cleaned = re.sub(r"[^\w\-. ]", "_", str(name))
     cleaned = cleaned.strip().lstrip(".")
     return cleaned or "unnamed"
+
+
+def _iter_score_chunk_files(chunks_dir: str):
+    """Yield (path, score) for chunk_*-score_*.txt files in a resume cache dir."""
+    import os
+    for chunk_fname in os.listdir(chunks_dir):
+        if "-score_" not in chunk_fname or not chunk_fname.endswith(".txt"):
+            continue
+        score = float(chunk_fname.split("-score_")[1].split(".txt")[0])
+        yield os.path.join(chunks_dir, chunk_fname), score


### PR DESCRIPTION
Resume treated any non-empty `event_*` directory as a retrieval cache hit, then parsed `-score_` out of every filename. A stray `notes.txt` raised `IndexError`. Skipping unmatched names alone still left a stray-only directory as an empty hit and skipped retrieval.

`iter_score_chunk_files` now selects only `*-score_*.txt` entries with a parseable score, and resume runs only when at least one such file exists.

Repro: a cache dir containing only `notes.txt` must not IndexError and must not count as a hit.