### PR TITLE
feat: add Atlas Cloud provider preset

### DIFF
--- a/tests/test_atlascloud_provider_preset.py
+++ b/tests/test_atlascloud_provider_preset.py
@@ -1,0 +1,60 @@
+"""Focused tests for the Atlas Cloud provider preset."""
+
+import os
+import unittest
+from unittest.mock import patch
+
+from utils.provider_presets import (
+    PROVIDER_PRESETS,
+    detect_provider_from_env,
+    resolve_chat_model_config,
+)
+
+
+class TestAtlasCloudProviderPreset(unittest.TestCase):
+    def test_preset_uses_openai_compatible_endpoint(self):
+        preset = PROVIDER_PRESETS["atlascloud"]
+
+        self.assertEqual(preset["base_url"], "https://api.atlascloud.ai/v1")
+        self.assertEqual(preset["env_key"], "ATLASCLOUD_API_KEY")
+        self.assertEqual(preset["default_model"], "deepseek-ai/deepseek-v4-pro")
+
+    def test_resolver_rewrites_provider_and_applies_defaults(self):
+        result = resolve_chat_model_config(
+            {"model_provider": "atlascloud", "api_key": "test-key"}
+        )
+
+        self.assertEqual(result["model_provider"], "openai")
+        self.assertEqual(result["base_url"], "https://api.atlascloud.ai/v1")
+        self.assertEqual(result["model"], "deepseek-ai/deepseek-v4-pro")
+
+    @patch.dict(os.environ, {"ATLASCLOUD_API_KEY": "env-key"}, clear=True)
+    def test_resolver_reads_api_key_from_environment(self):
+        result = resolve_chat_model_config(
+            {"model_provider": "atlascloud", "model": "custom-model"}
+        )
+
+        self.assertEqual(result["api_key"], "env-key")
+        self.assertEqual(result["model"], "custom-model")
+
+    @patch.dict(os.environ, {"ATLASCLOUD_API_KEY": "env-key"}, clear=True)
+    def test_environment_detection_includes_atlascloud(self):
+        self.assertEqual(detect_provider_from_env(), "atlascloud")
+
+    def test_explicit_values_are_preserved(self):
+        result = resolve_chat_model_config(
+            {
+                "model_provider": "atlascloud",
+                "model": "custom-model",
+                "base_url": "https://proxy.example.com/v1",
+                "api_key": "explicit-key",
+            }
+        )
+
+        self.assertEqual(result["model"], "custom-model")
+        self.assertEqual(result["base_url"], "https://proxy.example.com/v1")
+        self.assertEqual(result["api_key"], "explicit-key")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/provider_presets.py
+++ b/utils/provider_presets.py
@@ -28,6 +28,14 @@ PROVIDER_PRESETS: Dict[str, Dict[str, Any]] = {
         ],
         "temperature_range": (0.0, 1.0),
     },
+    "atlascloud": {
+        "base_url": "https://api.atlascloud.ai/v1",
+        "env_key": "ATLASCLOUD_API_KEY",
+        "default_model": "deepseek-ai/deepseek-v4-pro",
+        "models": [
+            "deepseek-ai/deepseek-v4-pro",
+        ],
+    },
 }
 
 


### PR DESCRIPTION
## Summary

- add an `atlascloud` chat model provider preset
- reuse the existing OpenAI-compatible provider resolution path
- source credentials from `ATLASCLOUD_API_KEY` and default to `deepseek-ai/deepseek-v4-pro`

## Validation

- existing provider preset tests: 27 passed
- Atlas Cloud provider preset tests: 5 passed
- `python3 -m compileall` for changed Python files
- Atlas Cloud model catalog: HTTP 200, default model present
- Atlas Cloud chat completions: HTTP 200, standard `choices` response

No README or documentation changes.
