### PR TITLE
Add MuAPI provider integration

### DIFF
--- a/agent_runtime/config.py
+++ b/agent_runtime/config.py
@@ -71,7 +71,7 @@ def image_base_url(workspace_root: str | Path = ".") -> str:
 
 
 def image_api_key(workspace_root: str | Path = ".") -> str:
-    return config_value("image", "api_key", ["VIMAX_IMAGE_API_KEY", "VIMAX_LLM_API_KEY", "VIMAX_API_KEY"], llm_api_key(workspace_root), workspace_root)
+    return config_value("image", "api_key", ["VIMAX_IMAGE_API_KEY", "MUAPI_API_KEY", "VIMAX_LLM_API_KEY", "VIMAX_API_KEY"], llm_api_key(workspace_root), workspace_root)
 
 
 
@@ -112,13 +112,15 @@ def video_base_url(workspace_root: str | Path = ".") -> str:
 
 
 def video_api_key(workspace_root: str | Path = ".") -> str:
-    return config_value("video", "api_key", ["VIMAX_VIDEO_API_KEY", "VIMAX_LLM_API_KEY", "VIMAX_API_KEY"], llm_api_key(workspace_root), workspace_root)
+    return config_value("video", "api_key", ["VIMAX_VIDEO_API_KEY", "MUAPI_API_KEY", "VIMAX_LLM_API_KEY", "VIMAX_API_KEY"], llm_api_key(workspace_root), workspace_root)
 
 
 def api_provider_from_base_url(base_url: str) -> str:
     normalized = base_url.strip().lower()
     if "openrouter.ai" in normalized:
         return "openrouter"
+    if "muapi.ai" in normalized:
+        return "muapi"
     if "yunwu.ai" in normalized:
         return "yunwu"
     return ""
@@ -127,7 +129,7 @@ def api_provider_from_base_url(base_url: str) -> str:
 def video_provider(workspace_root: str | Path = ".") -> str:
     """Infer the video API relay/provider from video.base_url.
 
-    This is not a model provider setting. OpenRouter/Yunwu are transport/API
+    This is not a model provider setting. OpenRouter/MuAPI/Yunwu are transport/API
     gateways here, so users should configure base_url and let the adapter pick
     the matching implementation.
     """

--- a/agent_runtime/vimax_adapters.py
+++ b/agent_runtime/vimax_adapters.py
@@ -22,9 +22,11 @@ from pipelines.novel2movie_pipeline import Novel2MoviePipeline
 from pipelines.idea2video_pipeline import Idea2VideoPipeline
 from pipelines.script2video_pipeline import Script2VideoPipeline
 from tools.image_generator_nanobanana_yunwu_api import ImageGeneratorNanobananaYunwuAPI
+from tools.image_generator_muapi import ImageGeneratorMuAPI
 from tools.image_generator_openrouter_api import ImageGeneratorOpenRouterAPI
 from tools.reranker_bge_silicon_api import RerankerBgeSiliconapi
 from tools.video_generator_openrouter_api import VideoGeneratorOpenRouterAPI
+from tools.video_generator_muapi import VideoGeneratorMuAPI
 from tools.video_generator_veo_yunwu_api import VideoGeneratorVeoYunwuAPI
 
 from .config import api_provider_from_base_url, embedding_api_key, embedding_base_url, embedding_model, embedding_model_provider, image_api_key, image_base_url, image_model, llm_api_key, llm_base_url, llm_model, llm_model_provider, reranker_api_key, reranker_base_url, reranker_model, video_api_key, video_base_url, video_model, video_provider
@@ -571,26 +573,31 @@ def _build_chat_model() -> Any:
     )
 
 
-def _build_image_generator() -> ImageGeneratorNanobananaYunwuAPI | ImageGeneratorOpenRouterAPI:
+def _build_image_generator() -> ImageGeneratorNanobananaYunwuAPI | ImageGeneratorMuAPI | ImageGeneratorOpenRouterAPI:
     api_key = image_api_key()
     if not api_key:
-        raise RuntimeError("VIMAX_IMAGE_API_KEY, VIMAX_LLM_API_KEY, or configs/agent.local.yaml image/llm api_key is required for image generation")
+        raise RuntimeError("VIMAX_IMAGE_API_KEY, MUAPI_API_KEY, VIMAX_LLM_API_KEY, or configs/agent.local.yaml image/llm api_key is required for image generation")
     model = image_model()
     base_url = image_base_url()
-    if api_provider_from_base_url(base_url) == "openrouter":
+    provider = api_provider_from_base_url(base_url)
+    if provider == "openrouter":
         return ImageGeneratorOpenRouterAPI(api_key=api_key, model=model, base_url=base_url)
+    if provider == "muapi":
+        return ImageGeneratorMuAPI(api_key=api_key, model=model, base_url=base_url)
     return ImageGeneratorNanobananaYunwuAPI(api_key=api_key, model=model, base_url=base_url)
 
 
-def _build_video_generator() -> VideoGeneratorVeoYunwuAPI | VideoGeneratorOpenRouterAPI:
+def _build_video_generator() -> VideoGeneratorVeoYunwuAPI | VideoGeneratorMuAPI | VideoGeneratorOpenRouterAPI:
     api_key = video_api_key()
     if not api_key:
-        raise RuntimeError("VIMAX_VIDEO_API_KEY, VIMAX_LLM_API_KEY, or configs/agent.local.yaml video/llm api_key is required for video generation")
+        raise RuntimeError("VIMAX_VIDEO_API_KEY, MUAPI_API_KEY, VIMAX_LLM_API_KEY, or configs/agent.local.yaml video/llm api_key is required for video generation")
     model = video_model()
     base_url = video_base_url()
     provider = video_provider().strip().lower()
     if provider == "openrouter":
         return VideoGeneratorOpenRouterAPI(api_key=api_key, model=model, base_url=base_url)
+    if provider == "muapi":
+        return VideoGeneratorMuAPI(api_key=api_key, model=model, base_url=base_url)
     if provider == "yunwu":
         return VideoGeneratorVeoYunwuAPI(api_key=api_key, t2v_model=model, ff2v_model=model, base_url=base_url)
     raise RuntimeError(f"Unsupported video base_url for automatic provider matching: {base_url}")

--- a/configs/agent.muapi.example.yaml
+++ b/configs/agent.muapi.example.yaml
@@ -1,0 +1,32 @@
+# MuAPI provider example for the ViMax TUI and Web UI.
+# Copy this file to configs/agent.local.yaml, then set the LLM values.
+# The image and video sections use MUAPI_API_KEY when their api_key is empty.
+
+llm:
+  model_provider: openai
+  model: <YOUR_LLM_MODEL>
+  base_url: <YOUR_LLM_BASE_URL>
+  api_key: ''
+
+image:
+  model: flux-kontext-dev-t2i
+  base_url: https://api.muapi.ai/api/v1
+  api_key: ''
+
+video:
+  model: veo3-fast-text-to-video
+  base_url: https://api.muapi.ai/api/v1
+  api_key: ''
+
+# Optional. Fill these only when using novel2video planning.
+embedding:
+  model_provider: openai
+  model: <YOUR_EMBEDDING_MODEL>
+  base_url: <YOUR_EMBEDDING_BASE_URL>
+  api_key: ''
+
+# Optional. Fill these only when using novel2video planning.
+reranker:
+  model: <YOUR_RERANKER_MODEL>
+  base_url: <YOUR_RERANKER_BASE_URL>
+  api_key: ''

--- a/configs/idea2video_muapi.yaml
+++ b/configs/idea2video_muapi.yaml
@@ -1,0 +1,32 @@
+chat_model:
+  init_args:
+    model: google/gemini-2.5-flash-lite-preview-09-2025
+    model_provider: openai
+    api_key: # Set the key for the selected chat provider.
+    base_url: https://openrouter.ai/api/v1
+  max_requests_per_minute: 500
+  max_requests_per_day: 2000
+
+image_generator:
+  class_path: tools.ImageGeneratorMuAPI
+  init_args:
+    # Leave blank to read MUAPI_API_KEY from the environment.
+    api_key:
+    text_to_image_model: flux-kontext-dev-t2i
+    image_to_image_model: flux-kontext-dev-i2i
+    base_url: https://api.muapi.ai/api/v1
+  max_requests_per_minute: 10
+  max_requests_per_day: 100
+
+video_generator:
+  class_path: tools.VideoGeneratorMuAPI
+  init_args:
+    # Leave blank to read MUAPI_API_KEY from the environment.
+    api_key:
+    t2v_model: veo3-fast-text-to-video
+    i2v_model: veo3-fast-image-to-video
+    base_url: https://api.muapi.ai/api/v1
+  max_requests_per_minute: 2
+  max_requests_per_day: 10
+
+working_dir: .working_dir/idea2video_muapi

--- a/configs/script2video_muapi.yaml
+++ b/configs/script2video_muapi.yaml
@@ -1,0 +1,32 @@
+chat_model:
+  init_args:
+    model: google/gemini-2.5-flash-lite-preview-09-2025
+    model_provider: openai
+    api_key: # Set the key for the selected chat provider.
+    base_url: https://openrouter.ai/api/v1
+  max_requests_per_minute: null
+  max_requests_per_day: null
+
+image_generator:
+  class_path: tools.ImageGeneratorMuAPI
+  init_args:
+    # Leave blank to read MUAPI_API_KEY from the environment.
+    api_key:
+    text_to_image_model: flux-kontext-dev-t2i
+    image_to_image_model: flux-kontext-dev-i2i
+    base_url: https://api.muapi.ai/api/v1
+  max_requests_per_minute: 2
+  max_requests_per_day: 50
+
+video_generator:
+  class_path: tools.VideoGeneratorMuAPI
+  init_args:
+    # Leave blank to read MUAPI_API_KEY from the environment.
+    api_key:
+    t2v_model: veo3-fast-text-to-video
+    i2v_model: veo3-fast-image-to-video
+    base_url: https://api.muapi.ai/api/v1
+  max_requests_per_minute: 2
+  max_requests_per_day: 10
+
+working_dir: .working_dir/script2video_muapi

--- a/readme.md
+++ b/readme.md
@@ -267,6 +267,8 @@ vimax tui resume <session_id>
 
 You can also keep `configs/agent.local.yaml` empty and provide the same values through environment variables, such as `VIMAX_LLM_API_KEY`, `VIMAX_IMAGE_API_KEY`, and `VIMAX_VIDEO_API_KEY`.
 
+For MuAPI-backed TUI or Web UI rendering, copy `configs/agent.muapi.example.yaml` to `configs/agent.local.yaml`, set `MUAPI_API_KEY`, and keep the image and video base URLs on `https://api.muapi.ai/api/v1`. The runtime selects the MuAPI adapters automatically.
+
 </details>
 
 <details>
@@ -323,6 +325,34 @@ video_generator:
 
 working_dir: .working_dir/idea2video
 ```
+
+### MuAPI provider
+
+ViMax also includes a MuAPI provider for its image and video generator interfaces. Set `MUAPI_API_KEY` before running a workflow; the provider uploads local reference frames, submits the selected MuAPI model, and polls the completed output automatically.
+
+```bash
+export MUAPI_API_KEY=<YOUR_MUAPI_API_KEY>
+```
+
+Use `configs/idea2video_muapi.yaml` or `configs/script2video_muapi.yaml`, or select the provider classes in an existing configuration:
+
+```yaml
+image_generator:
+  class_path: tools.ImageGeneratorMuAPI
+  init_args:
+    api_key:
+    text_to_image_model: flux-kontext-dev-t2i
+    image_to_image_model: flux-kontext-dev-i2i
+
+video_generator:
+  class_path: tools.VideoGeneratorMuAPI
+  init_args:
+    api_key:
+    t2v_model: veo3-fast-text-to-video
+    i2v_model: veo3-fast-image-to-video
+```
+
+`api_key:` may be left blank when `MUAPI_API_KEY` is set. See the [MuAPI API reference](https://muapi.ai/docs/api-reference) and [API-key setup](https://muapi.ai/access-keys) for account configuration and model-specific options.
 
 Then, provide a simple yet thoughtful idea and the corresponding creative requirements in main_idea2video.py.
 ```bash

--- a/tests/test_muapi_provider.py
+++ b/tests/test_muapi_provider.py
@@ -1,0 +1,157 @@
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from tools.image_generator_muapi import ImageGeneratorMuAPI
+from tools.muapi_client import MuAPIClient, MuAPIError
+from tools.video_generator_muapi import VideoGeneratorMuAPI
+from agent_runtime.vimax_adapters import _build_image_generator, _build_video_generator
+from agent_runtime.config import api_provider_from_base_url
+
+
+class FakeMuAPIClient:
+    def __init__(self, outputs):
+        self.outputs = outputs
+        self.uploaded_paths = []
+        self.generate_calls = []
+
+    async def upload_file(self, path):
+        self.uploaded_paths.append(path)
+        return f"https://uploads.example/{len(self.uploaded_paths)}.png"
+
+    async def generate(self, endpoint, payload):
+        self.generate_calls.append((endpoint, payload))
+        return self.outputs
+
+
+class MuAPIProviderTests(unittest.IsolatedAsyncioTestCase):
+    async def test_client_submits_polls_and_returns_outputs(self):
+        client = MuAPIClient(api_key="test-key", poll_interval=0, max_poll_attempts=3)
+        client._request_json = AsyncMock(
+            side_effect=[
+                {"request_id": "request-1"},
+                {"status": "processing"},
+                {"status": "completed", "outputs": ["https://cdn.example/image.png"]},
+            ]
+        )
+
+        outputs = await client.generate("flux-kontext-dev-t2i", {"prompt": "a tree"})
+
+        self.assertEqual(outputs, ["https://cdn.example/image.png"])
+        self.assertEqual(client._request_json.await_count, 3)
+
+    async def test_client_raises_for_failed_prediction(self):
+        client = MuAPIClient(api_key="test-key", poll_interval=0, max_poll_attempts=2)
+        client._request_json = AsyncMock(
+            side_effect=[
+                {"request_id": "request-2"},
+                {"status": "failed", "error": "model unavailable"},
+            ]
+        )
+
+        with self.assertRaisesRegex(MuAPIError, "model unavailable"):
+            await client.generate("veo3-fast-text-to-video", {"prompt": "a tree"})
+
+    async def test_image_provider_uploads_references_and_uses_override(self):
+        provider = ImageGeneratorMuAPI(
+            api_key="test-key",
+            text_to_image_model="custom-t2i",
+            image_to_image_model="custom-i2i",
+        )
+        fake_client = FakeMuAPIClient(["https://cdn.example/edited.webp"])
+        provider.client = fake_client
+
+        output = await provider.generate_single_image(
+            prompt="change the coat to red",
+            reference_image_paths=["character.png"],
+            aspect_ratio="1:1",
+        )
+
+        self.assertEqual(output.data, "https://cdn.example/edited.webp")
+        self.assertEqual(output.ext, "webp")
+        self.assertEqual(fake_client.uploaded_paths, ["character.png"])
+        self.assertEqual(fake_client.generate_calls[0][0], "custom-i2i")
+        self.assertEqual(
+            fake_client.generate_calls[0][1]["images_list"],
+            ["https://uploads.example/1.png"],
+        )
+
+    async def test_video_provider_uses_text_to_video_override(self):
+        provider = VideoGeneratorMuAPI(
+            api_key="test-key",
+            t2v_model="custom-video-model",
+        )
+        fake_client = FakeMuAPIClient(["https://cdn.example/clip.mp4"])
+        provider.client = fake_client
+
+        output = await provider.generate_single_video(
+            prompt="a slow camera move",
+            aspect_ratio="9:16",
+        )
+
+        self.assertEqual(output.data, "https://cdn.example/clip.mp4")
+        self.assertEqual(fake_client.generate_calls[0][0], "custom-video-model")
+        self.assertEqual(fake_client.generate_calls[0][1]["aspect_ratio"], "9:16")
+
+    async def test_video_provider_uploads_two_frames_for_image_to_video(self):
+        provider = VideoGeneratorMuAPI(api_key="test-key", i2v_model="custom-i2v")
+        fake_client = FakeMuAPIClient(["https://cdn.example/clip.mp4"])
+        provider.client = fake_client
+
+        await provider.generate_single_video(
+            prompt="match the final frame",
+            reference_image_paths=["first.png", "last.png"],
+        )
+
+        self.assertEqual(fake_client.generate_calls[0][0], "custom-i2v")
+        self.assertEqual(
+            fake_client.generate_calls[0][1]["images_list"],
+            ["https://uploads.example/1.png", "https://uploads.example/2.png"],
+        )
+
+    def test_single_model_names_pair_muapi_endpoints(self):
+        image_provider = ImageGeneratorMuAPI(
+            api_key="test-key",
+            model="flux-kontext-dev-t2i",
+        )
+        video_provider = VideoGeneratorMuAPI(
+            api_key="test-key",
+            model="veo3-fast-text-to-video",
+        )
+
+        self.assertEqual(image_provider.text_to_image_model, "flux-kontext-dev-t2i")
+        self.assertEqual(image_provider.image_to_image_model, "flux-kontext-dev-i2i")
+        self.assertEqual(video_provider.t2v_model, "veo3-fast-text-to-video")
+        self.assertEqual(video_provider.i2v_model, "veo3-fast-image-to-video")
+
+        reverse_video_provider = VideoGeneratorMuAPI(
+            api_key="test-key",
+            model="veo3-fast-image-to-video",
+        )
+        self.assertEqual(reverse_video_provider.t2v_model, "veo3-fast-text-to-video")
+        self.assertEqual(reverse_video_provider.i2v_model, "veo3-fast-image-to-video")
+
+        default_video_provider = VideoGeneratorMuAPI(
+            api_key="test-key",
+            model="veo3.1-fast",
+        )
+        self.assertEqual(default_video_provider.t2v_model, "veo3.1-fast-text-to-video")
+        self.assertEqual(default_video_provider.i2v_model, "veo3.1-fast-image-to-video")
+
+    def test_agent_factory_selects_muapi_from_base_url(self):
+        self.assertEqual(api_provider_from_base_url("https://api.muapi.ai/api/v1"), "muapi")
+        with patch("agent_runtime.vimax_adapters.image_api_key", return_value="secret"), \
+             patch("agent_runtime.vimax_adapters.image_model", return_value="flux-kontext-dev-t2i"), \
+             patch("agent_runtime.vimax_adapters.image_base_url", return_value="https://api.muapi.ai/api/v1"):
+            image_provider = _build_image_generator()
+        with patch("agent_runtime.vimax_adapters.video_api_key", return_value="secret"), \
+             patch("agent_runtime.vimax_adapters.video_model", return_value="veo3-fast-text-to-video"), \
+             patch("agent_runtime.vimax_adapters.video_base_url", return_value="https://api.muapi.ai/api/v1"), \
+             patch("agent_runtime.vimax_adapters.video_provider", return_value="muapi"):
+            video_provider = _build_video_generator()
+
+        self.assertIsInstance(image_provider, ImageGeneratorMuAPI)
+        self.assertIsInstance(video_provider, VideoGeneratorMuAPI)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -4,6 +4,7 @@ from .render_backend import RenderBackend
 
 # image generators
 from .image_generator_doubao_seedream_yunwu_api import ImageGeneratorDoubaoSeedreamYunwuAPI
+from .image_generator_muapi import ImageGeneratorMuAPI
 from .image_generator_nanobanana_google_api import ImageGeneratorNanobananaGoogleAPI
 from .image_generator_nanobanana_yunwu_api import ImageGeneratorNanobananaYunwuAPI
 from .image_generator_openrouter_api import ImageGeneratorOpenRouterAPI
@@ -15,6 +16,7 @@ from .reranker_bge_silicon_api import RerankerBgeSiliconapi
 from .video_generator_doubao_seedance_yunwu_api import VideoGeneratorDoubaoSeedanceYunwuAPI
 from .video_generator_omni_yunwu_api import VideoGeneratorOmniYunwuAPI, VideoGeneratorOminiYunwuAPI
 from .video_generator_openrouter_api import VideoGeneratorOpenRouterAPI
+from .video_generator_muapi import VideoGeneratorMuAPI
 from .video_generator_veo_google_api import VideoGeneratorVeoGoogleAPI
 from .video_generator_veo_yunwu_api import VideoGeneratorVeoYunwuAPI
 
@@ -24,6 +26,7 @@ __all__ = [
     "VideoGenerator",
     "RenderBackend",
     "ImageGeneratorDoubaoSeedreamYunwuAPI",
+    "ImageGeneratorMuAPI",
     "ImageGeneratorNanobananaGoogleAPI",
     "ImageGeneratorNanobananaYunwuAPI",
     "ImageGeneratorOpenRouterAPI",
@@ -32,6 +35,7 @@ __all__ = [
     "VideoGeneratorOmniYunwuAPI",
     "VideoGeneratorOminiYunwuAPI",
     "VideoGeneratorOpenRouterAPI",
+    "VideoGeneratorMuAPI",
     "VideoGeneratorVeoGoogleAPI",
     "VideoGeneratorVeoYunwuAPI",
 ]

--- a/tools/image_generator_muapi.py
+++ b/tools/image_generator_muapi.py
@@ -1,0 +1,151 @@
+"""MuAPI image provider for ViMax."""
+
+import math
+import re
+from typing import Any, List, Optional
+from urllib.parse import urlparse
+
+from interfaces.image_output import ImageOutput
+from tools.muapi_client import MuAPIClient
+from utils.rate_limiter import RateLimiter
+
+
+class ImageGeneratorMuAPI:
+    """Generate ViMax images through MuAPI's text and image endpoints."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        text_to_image_model: Optional[str] = None,
+        image_to_image_model: Optional[str] = None,
+        base_url: str = "https://api.muapi.ai/api/v1",
+        rate_limiter: Optional[RateLimiter] = None,
+        poll_interval: float = 3.0,
+        max_poll_attempts: int = 200,
+        timeout: float = 120.0,
+    ):
+        paired_text_model, paired_image_model = self._paired_models(model)
+        self.text_to_image_model = text_to_image_model or paired_text_model
+        self.image_to_image_model = image_to_image_model or paired_image_model
+        # Keep a single model attribute for the agent runtime's provider
+        # introspection and for consistency with the other ViMax adapters.
+        self.model = model or self.text_to_image_model
+        self.client = MuAPIClient(
+            api_key=api_key,
+            base_url=base_url,
+            rate_limiter=rate_limiter,
+            poll_interval=poll_interval,
+            max_poll_attempts=max_poll_attempts,
+            timeout=timeout,
+        )
+
+    async def generate_single_image(
+        self,
+        prompt: str,
+        reference_image_paths: Optional[List[str]] = None,
+        aspect_ratio: Optional[str] = None,
+        num_images: int = 1,
+        **kwargs,
+    ) -> ImageOutput:
+        """Generate one image and return the first completed output.
+
+        ViMax supplies local reference paths. MuAPI requires hosted URLs, so
+        references are uploaded before the generation request is submitted.
+        """
+
+        reference_image_paths = reference_image_paths or []
+        if not prompt:
+            raise ValueError("prompt must not be empty")
+        if not 1 <= num_images <= 4:
+            raise ValueError("num_images must be between 1 and 4")
+
+        progress = kwargs.get("progress")
+        resolved_aspect_ratio = self._resolve_aspect_ratio(
+            aspect_ratio=aspect_ratio,
+            size=kwargs.get("size"),
+        )
+        payload = {
+            "prompt": prompt,
+            "aspect_ratio": resolved_aspect_ratio,
+            "num_images": num_images,
+        }
+
+        if reference_image_paths:
+            payload["images_list"] = [
+                await self.client.upload_file(path) for path in reference_image_paths
+            ]
+            endpoint = self.image_to_image_model
+        else:
+            endpoint = self.text_to_image_model
+
+        self._emit_progress(
+            progress,
+            "image_generation",
+            f"Generating image with {endpoint}",
+            {"model": endpoint, "reference_count": len(reference_image_paths)},
+        )
+        outputs = await self.client.generate(endpoint, payload)
+        output_url = outputs[0]
+        self._emit_progress(
+            progress,
+            "image_completed",
+            "MuAPI image generation completed",
+            {"model": endpoint},
+        )
+        return ImageOutput(
+            fmt="url",
+            ext=self._extension_from_url(output_url, default="png"),
+            data=output_url,
+        )
+
+    @staticmethod
+    def _paired_models(model: Optional[str]) -> tuple[str, str]:
+        if not model:
+            return "flux-kontext-dev-t2i", "flux-kontext-dev-i2i"
+        if model.endswith("-t2i"):
+            return model, f"{model[:-4]}-i2i"
+        if model.endswith("-i2i"):
+            return f"{model[:-4]}-t2i", model
+        return model, model
+
+    @staticmethod
+    def _resolve_aspect_ratio(
+        aspect_ratio: Optional[str],
+        size: Optional[str],
+    ) -> str:
+        if aspect_ratio:
+            return aspect_ratio
+        if size:
+            match = re.fullmatch(r"\s*(\d+)x(\d+)\s*", str(size))
+            if match:
+                width, height = (int(value) for value in match.groups())
+                if width > 0 and height > 0:
+                    divisor = math.gcd(width, height)
+                    normalized = f"{width // divisor}:{height // divisor}"
+                    if normalized in {
+                        "9:16",
+                        "16:9",
+                        "1:1",
+                        "4:3",
+                        "3:4",
+                        "3:2",
+                        "2:3",
+                        "21:9",
+                        "9:21",
+                        "16:21",
+                    }:
+                        return normalized
+        return "16:9"
+
+    @staticmethod
+    def _extension_from_url(url: str, default: str) -> str:
+        suffix = urlparse(url).path.rsplit("/", 1)[-1].rsplit(".", 1)
+        if len(suffix) == 2 and suffix[1].isalnum():
+            return suffix[1].lower()
+        return default
+
+    @staticmethod
+    def _emit_progress(progress: Any, stage: str, message: str, metadata: dict[str, Any]) -> None:
+        if progress is not None:
+            progress(stage, message, metadata)

--- a/tools/muapi_client.py
+++ b/tools/muapi_client.py
@@ -1,0 +1,206 @@
+"""Small async client for MuAPI's submit-then-poll REST API."""
+
+import asyncio
+import json
+import logging
+import mimetypes
+import os
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+from utils.rate_limiter import RateLimiter
+
+
+class MuAPIError(RuntimeError):
+    """Raised when MuAPI rejects a request or a generation fails."""
+
+
+class MuAPIClient:
+    """Shared transport used by the image and video provider adapters.
+
+    MuAPI accepts local media through ``/upload_file`` and exposes the same
+    asynchronous lifecycle for every model: submit a job, then poll its
+    prediction result until it completes.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: str = "https://api.muapi.ai/api/v1",
+        rate_limiter: Optional[RateLimiter] = None,
+        poll_interval: float = 3.0,
+        max_poll_attempts: int = 200,
+        timeout: float = 120.0,
+    ):
+        self.api_key = api_key or os.getenv("MUAPI_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "MuAPI API key is required. Pass api_key or set MUAPI_API_KEY."
+            )
+
+        if poll_interval < 0:
+            raise ValueError("poll_interval must be non-negative")
+        if max_poll_attempts <= 0:
+            raise ValueError("max_poll_attempts must be positive")
+
+        self.base_url = base_url.rstrip("/")
+        self.rate_limiter = rate_limiter
+        self.poll_interval = poll_interval
+        self.max_poll_attempts = max_poll_attempts
+        self.timeout = timeout
+
+    async def _request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_payload: Optional[Dict[str, Any]] = None,
+        form_data: Optional[aiohttp.FormData] = None,
+    ) -> Any:
+        headers = {"x-api-key": self.api_key}
+        request_kwargs: Dict[str, Any] = {"headers": headers}
+        if json_payload is not None:
+            headers["Content-Type"] = "application/json"
+            request_kwargs["json"] = json_payload
+        elif form_data is not None:
+            request_kwargs["data"] = form_data
+
+        url = f"{self.base_url}/{path.lstrip('/')}"
+        timeout = aiohttp.ClientTimeout(total=self.timeout)
+
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.request(method, url, **request_kwargs) as response:
+                response_text = await response.text()
+                try:
+                    payload = json.loads(response_text) if response_text else {}
+                except json.JSONDecodeError as exc:
+                    raise MuAPIError(
+                        f"MuAPI returned invalid JSON ({response.status}) from {path}: "
+                        f"{response_text[:500]}"
+                    ) from exc
+
+                if response.status >= 400:
+                    raise MuAPIError(
+                        f"MuAPI request failed with HTTP {response.status} at {path}: "
+                        f"{payload}"
+                    )
+                return payload
+
+    async def submit(self, endpoint: str, payload: Dict[str, Any]) -> str:
+        """Submit a model request and return its prediction ID."""
+
+        if self.rate_limiter:
+            await self.rate_limiter.acquire()
+
+        response = await self._request_json("POST", endpoint, json_payload=payload)
+        request_id = response.get("request_id")
+        if request_id is None and isinstance(response.get("data"), dict):
+            request_id = response["data"].get("request_id")
+        if not request_id:
+            raise MuAPIError(f"MuAPI submission did not return request_id: {response}")
+        return request_id
+
+    async def generate(self, endpoint: str, payload: Dict[str, Any]) -> List[str]:
+        """Submit a job, poll it, and return its output URLs."""
+
+        request_id = await self.submit(endpoint, payload)
+        return await self.poll_result(request_id)
+
+    async def upload_file(self, path: str) -> str:
+        """Upload a local media file and return its hosted URL."""
+
+        if not os.path.isfile(path):
+            raise FileNotFoundError(path)
+
+        content_type = mimetypes.guess_type(path)[0] or "application/octet-stream"
+        form_data = aiohttp.FormData()
+        with open(path, "rb") as media_file:
+            form_data.add_field(
+                "file",
+                media_file,
+                filename=os.path.basename(path),
+                content_type=content_type,
+            )
+            response = await self._request_json(
+                "POST",
+                "upload_file",
+                form_data=form_data,
+            )
+
+        upload_url = response.get("url")
+        if upload_url is None and isinstance(response.get("data"), dict):
+            upload_url = response["data"].get("url")
+        if not upload_url:
+            raise MuAPIError(f"MuAPI upload did not return a URL: {response}")
+        return upload_url
+
+    async def poll_result(self, request_id: str) -> List[str]:
+        """Poll one prediction until it completes or fails."""
+
+        for attempt in range(self.max_poll_attempts):
+            response = await self._request_json(
+                "GET",
+                f"predictions/{request_id}/result",
+            )
+            result = response
+            if isinstance(response.get("data"), dict) and "status" not in response:
+                result = response["data"]
+
+            status = result.get("status")
+            if status == "completed":
+                outputs = self._extract_outputs(result)
+                if not outputs:
+                    raise MuAPIError(
+                        f"MuAPI prediction {request_id} completed without outputs: {response}"
+                    )
+                return outputs
+
+            if status in {"failed", "cancelled"}:
+                error = result.get("error") or result.get("message") or result
+                raise MuAPIError(f"MuAPI prediction {request_id} {status}: {error}")
+
+            if attempt == self.max_poll_attempts - 1:
+                raise MuAPIError(
+                    f"MuAPI prediction {request_id} did not complete after "
+                    f"{self.max_poll_attempts} polls (last status: {status!r})"
+                )
+
+            logging.info(
+                "MuAPI prediction %s is %s; polling again in %ss",
+                request_id,
+                status or "unknown",
+                self.poll_interval,
+            )
+            await asyncio.sleep(self.poll_interval)
+
+        raise AssertionError("poll loop should always return or raise")
+
+    @staticmethod
+    def _extract_outputs(result: Dict[str, Any]) -> List[str]:
+        outputs = result.get("outputs")
+        if outputs is None:
+            outputs = result.get("output")
+
+        if outputs is None:
+            for key in ("image", "video", "audio"):
+                media = result.get(key)
+                if isinstance(media, dict) and media.get("url"):
+                    outputs = [media["url"]]
+                    break
+                if isinstance(media, str):
+                    outputs = [media]
+                    break
+
+        if isinstance(outputs, str):
+            outputs = [outputs]
+        if not isinstance(outputs, list):
+            return []
+
+        normalized: List[str] = []
+        for output in outputs:
+            if isinstance(output, str) and output:
+                normalized.append(output)
+            elif isinstance(output, dict) and output.get("url"):
+                normalized.append(output["url"])
+        return normalized

--- a/tools/video_generator_muapi.py
+++ b/tools/video_generator_muapi.py
@@ -1,0 +1,124 @@
+"""MuAPI video provider for ViMax."""
+
+from typing import Any, List, Optional
+from urllib.parse import urlparse
+
+from interfaces.video_output import VideoOutput
+from tools.muapi_client import MuAPIClient
+from utils.rate_limiter import RateLimiter
+
+
+class VideoGeneratorMuAPI:
+    """Generate ViMax clips through MuAPI text/image-to-video endpoints."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        t2v_model: Optional[str] = None,
+        i2v_model: Optional[str] = None,
+        base_url: str = "https://api.muapi.ai/api/v1",
+        rate_limiter: Optional[RateLimiter] = None,
+        poll_interval: float = 3.0,
+        max_poll_attempts: int = 200,
+        timeout: float = 120.0,
+    ):
+        paired_text_model, paired_image_model = self._paired_models(model)
+        self.t2v_model = t2v_model or paired_text_model
+        self.i2v_model = i2v_model or paired_image_model
+        self.model = model or self.t2v_model
+        self.client = MuAPIClient(
+            api_key=api_key,
+            base_url=base_url,
+            rate_limiter=rate_limiter,
+            poll_interval=poll_interval,
+            max_poll_attempts=max_poll_attempts,
+            timeout=timeout,
+        )
+
+    async def generate_single_video(
+        self,
+        prompt: str,
+        reference_image_paths: Optional[List[str]] = None,
+        aspect_ratio: str = "16:9",
+        **kwargs: Any,
+    ) -> VideoOutput:
+        """Generate one clip and return its first completed output.
+
+        The default Veo 3 / Veo 3.1 endpoints accept one or more image URLs in
+        ``images_list``. The ``resolution`` and ``duration`` arguments used
+        by some other ViMax providers are intentionally not sent because
+        they are not part of the default MuAPI Veo 3 request schema.
+        """
+
+        reference_image_paths = reference_image_paths or []
+        if not prompt:
+            raise ValueError("prompt must not be empty")
+        if len(reference_image_paths) > 2:
+            raise ValueError("reference_image_paths must contain no more than 2 images")
+        if aspect_ratio not in {"9:16", "16:9"}:
+            raise ValueError("MuAPI Veo 3 endpoints support 9:16 and 16:9 aspect ratios")
+
+        payload = {
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+        }
+        if reference_image_paths:
+            payload["images_list"] = [
+                await self.client.upload_file(path) for path in reference_image_paths
+            ]
+            endpoint = self.i2v_model
+        else:
+            endpoint = self.t2v_model
+
+        progress = kwargs.get("progress")
+        self._emit_progress(
+            progress,
+            "video_create",
+            f"Creating MuAPI video generation task with {endpoint}",
+            {"model": endpoint, "frame_count": len(reference_image_paths)},
+        )
+        outputs = await self.client.generate(endpoint, payload)
+        output_url = outputs[0]
+        self._emit_progress(
+            progress,
+            "video_completed",
+            "MuAPI video generation completed",
+            {"model": endpoint},
+        )
+        return VideoOutput(
+            fmt="url",
+            ext=self._extension_from_url(output_url, default="mp4"),
+            data=output_url,
+        )
+
+    @staticmethod
+    def _paired_models(model: Optional[str]) -> tuple[str, str]:
+        if not model:
+            return "veo3-fast-text-to-video", "veo3-fast-image-to-video"
+        aliases = {
+            "veo3-fast": ("veo3-fast-text-to-video", "veo3-fast-image-to-video"),
+            "veo3.1-fast": ("veo3.1-fast-text-to-video", "veo3.1-fast-image-to-video"),
+        }
+        if model in aliases:
+            return aliases[model]
+
+        text_suffix = "-text-to-video"
+        image_suffix = "-image-to-video"
+        if model.endswith(text_suffix):
+            return model, f"{model[:-len(text_suffix)]}{image_suffix}"
+        if model.endswith(image_suffix):
+            return f"{model[:-len(image_suffix)]}{text_suffix}", model
+        return model, model
+
+    @staticmethod
+    def _extension_from_url(url: str, default: str) -> str:
+        suffix = urlparse(url).path.rsplit("/", 1)[-1].rsplit(".", 1)
+        if len(suffix) == 2 and suffix[1].isalnum():
+            return suffix[1].lower()
+        return default
+
+    @staticmethod
+    def _emit_progress(progress: Any, stage: str, message: str, metadata: dict[str, Any]) -> None:
+        if progress is not None:
+            progress(stage, message, metadata)


### PR DESCRIPTION
## Summary

- Add MuAPI image and video generators using `MUAPI_API_KEY` and the standard `https://api.muapi.ai/api/v1` base URL.
- Support local reference uploads, asynchronous submit → poll handling, model overrides, and ViMax output normalization.
- Register MuAPI in the agent runtime, add ready-to-copy configs, and document TUI/Web UI setup.
- Add mocked provider tests covering success, failure, uploads, model pairing, and runtime selection.

## Verification

- `UV_CACHE_DIR=/private/tmp/vimax-uv-cache uv run --no-sync python -m unittest tests.test_muapi_provider -v`
- `UV_CACHE_DIR=/private/tmp/vimax-uv-cache uv run --no-sync python -m unittest discover -s tests`
- Ruff, YAML validation, and `git diff --check`

The integration follows MuAPI's documented `x-api-key`, file upload, and submit-then-poll APIs:

- https://muapi.ai/docs/api-reference
- https://muapi.ai/docs/file-upload
