### PR TITLE
fix: add Windows file locking to SessionIndex

### DIFF
--- a/agent_runtime/session_index.py
+++ b/agent_runtime/session_index.py
@@ -15,6 +15,11 @@ try:
 except ImportError:  # pragma: no cover - non-POSIX platforms
     fcntl = None
 
+try:
+    import msvcrt
+except ImportError:  # pragma: no cover - non-Windows platforms
+    msvcrt = None
+
 
 STALE_KEYS = ["story", "characters", "script", "storyboard", "shot_descriptions", "camera_tree", "frames", "clips", "final_video"]
 
@@ -50,19 +55,36 @@ class SessionIndex:
             self.memory_path.write_text("# User Preferences\n", encoding="utf-8")
         if not self.sessions_path.exists():
             self.save({"active_session_id": "", "sessions": {}})
+        if msvcrt is not None:
+            # msvcrt.locking locks a byte range, so the file needs at least
+            # one byte before it can be locked. Written once here, outside
+            # any concurrent access, since Windows enforces this lock as
+            # mandatory: a bare read() on the lock file while another thread
+            # holds it would itself raise PermissionError.
+            lock_path = self.vimax_dir / "sessions.lock"
+            if not lock_path.exists():
+                lock_path.write_bytes(b"\0")
 
     @contextmanager
     def _locked(self):
-        if fcntl is None:
+        if fcntl is None and msvcrt is None:
             yield
             return
         lock_path = self.vimax_dir / "sessions.lock"
-        with open(lock_path, "a+", encoding="utf-8") as handle:
-            fcntl.flock(handle, fcntl.LOCK_EX)
+        with open(lock_path, "a+b") as handle:
+            if fcntl is not None:
+                fcntl.flock(handle, fcntl.LOCK_EX)
+            else:
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
             try:
                 yield
             finally:
-                fcntl.flock(handle, fcntl.LOCK_UN)
+                if fcntl is not None:
+                    fcntl.flock(handle, fcntl.LOCK_UN)
+                else:
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
 
     def load(self) -> dict[str, Any]:
         try:


### PR DESCRIPTION
## Summary
- `SessionIndex._locked()` only implemented file locking via POSIX `fcntl`, which is `None` on Windows. This silently disabled the locking that the docstring on `_synchronized` promises, so concurrent session writes on Windows can drop each other's data and `save()`'s `os.replace()` can raise `PermissionError`.
- Adds an `msvcrt.locking()` fallback for Windows, matching the existing `fcntl.flock` behavior on POSIX.
- The lock file's required byte is written once in `__init__` (before any concurrent access exists) rather than on each lock acquisition, because Windows enforces `msvcrt` locks as mandatory — a bare `read()` on the lock file while another thread holds the lock would itself raise `PermissionError`.

## Test plan
- [x] `tests/test_robustness.py::TestSessionIndexDurability::test_concurrent_creates_do_not_lose_sessions` — previously lost roughly half of 80 concurrently created sessions on Windows; now passes consistently across repeated runs.
- [x] Full `pytest tests/` suite on Windows: 182/184 passing (remaining 2 failures are pre-existing, unrelated test-portability issues — a hardcoded `/tmp` path and a test reading a file without specifying UTF-8 encoding — not touched by this change).